### PR TITLE
Add basic authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
+# PlayMate
 
+This is a simple PHP demo project for finding sport partners. The project was updated to include a basic authentication system using SQLite.
+
+## Features
+- User registration and login with hashed passwords
+- Session-based authentication with logout
+- Bootstrap-based UI for login and registration pages
+- Existing matching and chat functionality remain unchanged
+
+To run locally, use PHP's built-in server:
+
+```bash
+php -S localhost:8000
+```
+
+The database file `playmate.db` will be created automatically on first use.

--- a/db.php
+++ b/db.php
@@ -1,0 +1,16 @@
+<?php
+// Database connection using SQLite
+$dsn = 'sqlite:' . __DIR__ . '/playmate.db';
+try {
+    $pdo = new PDO($dsn);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    // create users table if not exists
+    $pdo->exec("CREATE TABLE IF NOT EXISTS users (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        username TEXT UNIQUE,
+        password TEXT
+    )");
+} catch (PDOException $e) {
+    die('Connection failed: ' . $e->getMessage());
+}
+?>

--- a/index.php
+++ b/index.php
@@ -1,3 +1,6 @@
+<?php
+session_start();
+?>
 <!DOCTYPE html>
 <html lang="en">
 
@@ -60,7 +63,14 @@
                         <a href="#about">About</a>
                     </li>
                     <li class="page-scroll">
-                        <a href="#contact">Register</a>
+                        <?php if (isset($_SESSION['user'])): ?>
+                            <a href="logout.php">Logout (<?php echo htmlspecialchars($_SESSION['user']); ?>)</a>
+                        <?php else: ?>
+                            <a href="login.php">Login</a>
+                        <?php endif; ?>
+                    </li>
+                    <li class="page-scroll">
+                        <a href="register.php">Register</a>
                     </li>
                 </ul>
             </div>

--- a/index.php
+++ b/index.php
@@ -69,9 +69,11 @@ session_start();
                             <a href="login.php">Login</a>
                         <?php endif; ?>
                     </li>
+                    <?php if (!isset($_SESSION['user'])): ?>
                     <li class="page-scroll">
                         <a href="register.php">Register</a>
                     </li>
+                    <?php endif; ?>
                 </ul>
             </div>
             <!-- /.navbar-collapse -->

--- a/login.php
+++ b/login.php
@@ -1,0 +1,45 @@
+<?php
+session_start();
+require 'db.php';
+$message = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = trim($_POST['username']);
+    $password = $_POST['password'];
+    $stmt = $pdo->prepare('SELECT * FROM users WHERE username = ?');
+    $stmt->execute([$username]);
+    $user = $stmt->fetch(PDO::FETCH_ASSOC);
+    if ($user && password_verify($password, $user['password'])) {
+        $_SESSION['user'] = $user['username'];
+        header('Location: index.php');
+        exit;
+    } else {
+        $message = 'Invalid credentials.';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+    <link href="css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="container">
+    <h1 class="mt-5">Login</h1>
+    <?php if ($message): ?>
+        <div class="alert alert-danger"><?php echo $message; ?></div>
+    <?php endif; ?>
+    <form method="post">
+        <div class="form-group">
+            <label>Username</label>
+            <input type="text" name="username" class="form-control" required>
+        </div>
+        <div class="form-group">
+            <label>Password</label>
+            <input type="password" name="password" class="form-control" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Login</button>
+    </form>
+    <p class="mt-3">No account? <a href="register.php">Register here</a></p>
+</body>
+</html>

--- a/login.php
+++ b/login.php
@@ -1,19 +1,28 @@
 <?php
 session_start();
 require 'db.php';
+
+if (empty($_SESSION['token'])) {
+    $_SESSION['token'] = bin2hex(random_bytes(32));
+}
+
 $message = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $username = trim($_POST['username']);
-    $password = $_POST['password'];
-    $stmt = $pdo->prepare('SELECT * FROM users WHERE username = ?');
-    $stmt->execute([$username]);
-    $user = $stmt->fetch(PDO::FETCH_ASSOC);
-    if ($user && password_verify($password, $user['password'])) {
-        $_SESSION['user'] = $user['username'];
-        header('Location: index.php');
-        exit;
+    if (!isset($_POST['token']) || $_POST['token'] !== $_SESSION['token']) {
+        $message = 'Invalid request.';
     } else {
-        $message = 'Invalid credentials.';
+        $username = trim($_POST['username']);
+        $password = $_POST['password'];
+        $stmt = $pdo->prepare('SELECT * FROM users WHERE username = ?');
+        $stmt->execute([$username]);
+        $user = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($user && password_verify($password, $user['password'])) {
+            $_SESSION['user'] = $user['username'];
+            header('Location: index.php');
+            exit;
+        } else {
+            $message = 'Invalid credentials.';
+        }
     }
 }
 ?>
@@ -30,6 +39,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <div class="alert alert-danger"><?php echo $message; ?></div>
     <?php endif; ?>
     <form method="post">
+        <input type="hidden" name="token" value="<?php echo htmlspecialchars($_SESSION['token']); ?>">
         <div class="form-group">
             <label>Username</label>
             <input type="text" name="username" class="form-control" required>

--- a/login.php
+++ b/login.php
@@ -17,6 +17,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $stmt->execute([$username]);
         $user = $stmt->fetch(PDO::FETCH_ASSOC);
         if ($user && password_verify($password, $user['password'])) {
+            session_regenerate_id(true);
             $_SESSION['user'] = $user['username'];
             header('Location: index.php');
             exit;

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,6 @@
+<?php
+session_start();
+session_destroy();
+header('Location: index.php');
+exit;
+?>

--- a/register.php
+++ b/register.php
@@ -1,21 +1,31 @@
 <?php
 session_start();
 require 'db.php';
+
+if (empty($_SESSION['token'])) {
+    $_SESSION['token'] = bin2hex(random_bytes(32));
+}
+
 $message = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $username = trim($_POST['username']);
-    $password = $_POST['password'];
-    if ($username && $password) {
-        $hash = password_hash($password, PASSWORD_DEFAULT);
-        $stmt = $pdo->prepare('INSERT INTO users (username, password) VALUES (?, ?)');
-        try {
-            $stmt->execute([$username, $hash]);
-            $message = 'Registration successful. You can now <a href="login.php">login</a>.';
-        } catch (PDOException $e) {
-            $message = 'Error: ' . $e->getMessage();
-        }
+    if (!isset($_POST['token']) || $_POST['token'] !== $_SESSION['token']) {
+        $message = 'Invalid request.';
     } else {
-        $message = 'Please fill in all fields.';
+        $username = trim($_POST['username']);
+        $password = $_POST['password'];
+        if ($username && $password) {
+            $hash = password_hash($password, PASSWORD_DEFAULT);
+            $stmt = $pdo->prepare('INSERT INTO users (username, password) VALUES (?, ?)');
+            try {
+                $stmt->execute([$username, $hash]);
+                $message = 'Registration successful. You can now <a href="login.php">login</a>.';
+            } catch (PDOException $e) {
+                error_log($e->getMessage());
+                $message = 'An error occurred while registering. Please try again.';
+            }
+        } else {
+            $message = 'Please fill in all fields.';
+        }
     }
 }
 ?>
@@ -32,6 +42,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <div class="alert alert-info"><?php echo $message; ?></div>
     <?php endif; ?>
     <form method="post">
+        <input type="hidden" name="token" value="<?php echo htmlspecialchars($_SESSION['token']); ?>">
         <div class="form-group">
             <label>Username</label>
             <input type="text" name="username" class="form-control" required>

--- a/register.php
+++ b/register.php
@@ -1,0 +1,46 @@
+<?php
+session_start();
+require 'db.php';
+$message = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = trim($_POST['username']);
+    $password = $_POST['password'];
+    if ($username && $password) {
+        $hash = password_hash($password, PASSWORD_DEFAULT);
+        $stmt = $pdo->prepare('INSERT INTO users (username, password) VALUES (?, ?)');
+        try {
+            $stmt->execute([$username, $hash]);
+            $message = 'Registration successful. You can now <a href="login.php">login</a>.';
+        } catch (PDOException $e) {
+            $message = 'Error: ' . $e->getMessage();
+        }
+    } else {
+        $message = 'Please fill in all fields.';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Register</title>
+    <link href="css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="container">
+    <h1 class="mt-5">Register</h1>
+    <?php if ($message): ?>
+        <div class="alert alert-info"><?php echo $message; ?></div>
+    <?php endif; ?>
+    <form method="post">
+        <div class="form-group">
+            <label>Username</label>
+            <input type="text" name="username" class="form-control" required>
+        </div>
+        <div class="form-group">
+            <label>Password</label>
+            <input type="password" name="password" class="form-control" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Register</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- introduce SQLite database connection
- add user registration and login pages
- add logout and link auth actions from navbar
- describe new setup in README

## Testing
- `php -l db.php`
- `php -l register.php`
- `php -l login.php`
- `php -l logout.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_683f529bd8288330aa6dd7bd411f61c4